### PR TITLE
feat: add global ListenBrainz API token

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,29 @@
         "labs.api.listenbrainz.org"
       ]
     }
+  },
+  "config": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string",
+          "title": "API Token",
+          "description": "Your ListenBrainz API token for authenticated requests"
+        }
+      }
+    },
+    "uiSchema": {
+      "type": "VerticalLayout",
+      "elements": [
+        {
+          "type": "Control",
+          "scope": "#/properties/token",
+          "options": {
+            "multi": true
+          }
+        }
+      ]
+    }
   }
 }

--- a/plugin.go
+++ b/plugin.go
@@ -63,11 +63,21 @@ func processRatelimit(resp *pdk.HTTPResponse) {
 	}
 }
 
+func getToken() string {
+	token, _ := pdk.GetConfig("token")
+	return token
+}
+
 func listenBrainzRequest(endpoint string, params url.Values) ([]byte, error) {
 	url := fmt.Sprintf("%s%s?%s", lbzEndpoint, endpoint, params.Encode())
 	req := pdk.NewHTTPRequest(pdk.MethodGet, url)
 	req.SetHeader("Accept", "application/json")
 	req.SetHeader("User-Agent", userAgent)
+
+	token := getToken()
+	if token != "" {
+		req.SetHeader("Authorization", "Token "+token)
+	}
 
 	resp := req.Send()
 


### PR DESCRIPTION
The ListenBrainz readthedocs site indicates that "Requests that provide the *Authorization* header with a valid user token may recieve higher rate limits than those without valid user tokens.